### PR TITLE
Added suport for ghc 7.4.1 Safe Haskell oddities

### DIFF
--- a/LIO/Concurrent/LMVar/TCB.hs
+++ b/LIO/Concurrent/LMVar/TCB.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE CPP #-}
-#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 702)
+#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 702) && (__GLASGOW_HASKELL__ < 704)
 {-# LANGUAGE SafeImports #-}
+#endif
+#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 704)
+{-# LANGUAGE Unsafe #-}
 #endif
 {-|
 This module provides an implementation for labeled MVars.  A labeled

--- a/LIO/FS.hs
+++ b/LIO/FS.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 702)
+#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 702) && (__GLASGOW_HASKELL__ < 704)
 {-# LANGUAGE SafeImports #-}
 #endif
 {-# LANGUAGE DeriveDataTypeable #-}

--- a/LIO/LIORef/TCB.hs
+++ b/LIO/LIORef/TCB.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE CPP #-}
-#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 702)
+#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 702) && (__GLASGOW_HASKELL__ < 704)
 {-# LANGUAGE SafeImports #-}
+#endif
+#if defined(__GLASGOW_HASKELL__) && (__GLASGOW_HASKELL__ >= 704)
+{-# LANGUAGE Unsafe #-}
 #endif
 -- |This module implements labeled IORefs.  The interface is analogous
 -- to "Data.IORef", but the operations take place in the LIO monad.

--- a/LIO/TCB.hs
+++ b/LIO/TCB.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 702
+#if __GLASGOW_HASKELL__ >= 702 && __GLASGOW_HASKELL__ < 704
 {-# LANGUAGE SafeImports #-}
 #endif
 #if __GLASGOW_HASKELL__ >= 704


### PR DESCRIPTION
Basically bounded included SafeImports pragma to only 7.2 as 7.4 doesn't have that pragma anymore (part of the compiler by default) and added Unstrusted pragma where necessary
