### PR TITLE
fix bug in withPrivileges, add dropPrivileges

### DIFF
--- a/LIO/Safe.hs
+++ b/LIO/Safe.hs
@@ -11,6 +11,7 @@ module LIO.Safe ( Label(..)
                  , Priv(..), noPrivs
                  , getPrivileges, withPrivileges
                  , withCombinedPrivs 
+                 , dropPrivileges 
                  , LIO, LabelState
                  , evalLIO
                  , getLabel, setLabelP
@@ -32,6 +33,7 @@ import LIO.TCB ( Label(..)
                , Priv(..), noPrivs
                , getPrivileges, withPrivileges
                , withCombinedPrivs 
+               , dropPrivileges 
                , LIO, LabelState
                , evalLIO
                , getLabel, setLabelP

--- a/lio.cabal
+++ b/lio.cabal
@@ -1,5 +1,5 @@
 Name:           lio
-Version:        0.1.2
+Version:        0.1.3
 build-type:     Simple
 License:        GPL
 License-File:   LICENSE
@@ -66,7 +66,7 @@ Library
                  cereal >= 0.3.3 && < 0.4,
                  base64-bytestring >= 0.1.1.0
 
-  ghc-options: -Wall -Werror -fno-warn-orphans
+  ghc-options: -Wall -fno-warn-orphans
 
   Exposed-modules:
     -- Core:


### PR DESCRIPTION
- withPrivileges no longer mconcat's with underlying privileges, so withPriviliges noPrivs is an action with no underlying priviliges, etc.
- dropPrivilges allows a computation to drop all underlying privileges. We do not expose setPrivileges as it is more likely to be used in an unsafe fashion.
