### PR TITLE
Avoid conduit build failure (GHC 7.6.3, cabal 1.20)

### DIFF
--- a/lio-simple/lio-simple.cabal
+++ b/lio-simple/lio-simple.cabal
@@ -38,7 +38,7 @@ library
   build-depends:
       base < 6
     , bytestring
-    , conduit
+    , conduit            < 1.1.*
     , filepath
     , lio                >= 0.11.4
     , simple             == 0.8.1.*


### PR DESCRIPTION
Under GHC 7.6.3 lio-simple 0.0.2.2 fails to build unless conduit < 1.1._. Getting conduit build problem out of the way by constraining to 1.0._ range. Probably not the right long-term solution, but unblocks me.

$ ghc --version
The Glorious Glasgow Haskell Compilation System, version 7.6.3
$ cabal --version
cabal-install version 1.20.0.0
using version 1.20.0.0 of the Cabal library
